### PR TITLE
Documentation overhaul

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -125,4 +125,73 @@ Product (Edition level)
     - Price and quantity per variant
 ```
 
+### Managing product categories
+
+Bookhead helps you organize your products into categories for your online store. Your point-of-sale system uses category codes (like "FM" for Fiction-Mystery), and Bookhead lets you map these to customer-friendly display categories (like "Fiction" or "Mystery"). This works for both Squarespace and Shopify.
+
+**How it works:**
+
+1. **Display categories** are the broad groupings customers see on your website (e.g., "Fiction", "History", "Children's Books")
+2. **Store categories** are the codes from your point-of-sale system
+3. You map store categories to display categories in Bookhead
+4. When you export to Squarespace, products get tagged with both the display category and the store category name
+
+#### Setting up categories in Bookhead
+
+**Step 1: Create display categories**
+
+1. Go to **Categories** in the staff menu
+2. Click **Create category**
+3. Enter a name like "Fiction" or "Children's Books"
+4. Repeat for each category you want on your website
+
+**Step 2: Map your store categories**
+
+1. Go to **Categories** → **Mappings**
+2. You'll see all your point-of-sale category codes
+3. For each code, select a display category from the dropdown
+4. The mapping saves automatically
+
+**Step 3: (Optional) Edit category names**
+
+Your point-of-sale category names might look ugly (like "FICTION-MYSTERY/DETECTIVE"). You can give them friendlier names:
+
+1. In the mappings view, click **edit** next to any category name
+2. Enter a friendlier name like "Mystery & Detective"
+3. Press Enter or click **save**
+
+This custom name will be used as a tag on your Squarespace products.
+
+#### Importing categories to Squarespace
+
+Squarespace doesn't allow setting categories via API, so you'll need to import them via CSV. Here's how:
+
+**Step 1: Create categories in Squarespace first**
+
+Before importing, you need to create the category structure in Squarespace:
+
+1. In Squarespace, go to your store and open any product
+2. Scroll down to **Categories**
+3. Click **Add Category** and create each display category (e.g., "Fiction", "History")
+4. These must match exactly what you created in Bookhead
+
+[Squarespace's guide to product categories →](https://support.squarespace.com/hc/en-us/articles/206540047-Organizing-products)
+
+**Step 2: Export from Bookhead**
+
+1. Go to **Channels** → your Squarespace channel → **Products**
+2. Click **Export CSV**
+3. Save the file
+
+**Step 3: Import to Squarespace**
+
+1. In Squarespace, go to **Commerce** → **Inventory** → **Products**
+2. Click **Import** (or the three dots menu → Import)
+3. Select your CSV file
+4. Squarespace will match products by SKU and update their categories
+
+**Important:** The import updates existing products - it won't create duplicates. Products are matched by their SKU (ISBN).
+
+[Squarespace's CSV import guide →](https://support.squarespace.com/hc/en-us/articles/205812328-Importing-products-with-a-CSV)
+
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 4
+---
+
+# Collections and staff picks
+
+Bookhead lets you create curated collections of books to feature on your website and sales channels. Collections are perfect for highlighting staff recommendations, seasonal themes, or any grouping you want to showcase.
+
+## Collections
+
+Collections are curated lists of specific books from your inventory. Use them for:
+
+- **Themed displays**: "Summer Reading", "Holiday Gift Guide", "Local Authors"
+- **Marketing campaigns**: Books for a newsletter, social media feature, or in-store display
+- **Website navigation**: Featured sections on your storefront
+
+### Creating a collection
+
+1. Go to **Collections** in the staff menu
+2. Click **Create collection**
+3. Enter a name for your collection (e.g., "Summer Reading 2024")
+4. Search for books to add using ISBN or title
+5. Click **Add** to include books in the collection
+6. Click **Save**
+
+### Managing collections
+
+From the collections list, you can:
+
+- **View** the books in each collection
+- **Edit** to add or remove books
+- **Delete** collections you no longer need
+
+### How collections sync to channels
+
+Collections sync to **Shopify** as Custom Collections. When you create or update a collection in Bookhead, it automatically syncs to your Shopify store within 15 minutes.
+
+**Note:** Squarespace doesn't support collections via API. For Squarespace, use [categories](/docs/channels#managing-product-categories) instead.
+
+## Staff picks
+
+Staff picks are a special type of collection that highlights books recommended by your team. They're a great way to add a personal touch to your online store.
+
+### How staff picks work
+
+Staff picks are connected to **reviews**. When a staff member writes a review for a book:
+
+1. The book is automatically added to that staff member's "Staff Picks" collection
+2. The collection is named after the reviewer (e.g., "Margaret's Picks")
+3. The collection syncs to your sales channels
+
+### Creating a staff pick
+
+1. Go to **Staff Picks** in the staff menu
+2. Click **New review**
+3. Search for the book you want to recommend
+4. Write your review
+5. Click **Save**
+
+The book is now in your staff picks collection and will sync to connected channels.
+
+### Managing staff picks
+
+From the staff picks page, you can:
+
+- **View** all reviews and their associated books
+- **Edit** existing reviews
+- **Delete** reviews (removes the book from staff picks)
+
+### Displaying staff picks
+
+Staff picks collections work like regular collections - they sync to Shopify as Custom Collections. You can feature them on your website's homepage, navigation, or anywhere you display collections.
+
+## Collections vs. categories
+
+It's easy to confuse collections and categories. Here's the difference:
+
+| | Collections | Categories |
+|--|-------------|------------|
+| **What they are** | Curated lists of specific books | Organizational groupings based on genre/type |
+| **How they're created** | You manually add books | Books are automatically included based on their point-of-sale category code |
+| **Use case** | "Staff Picks", "Holiday Gifts" | "Fiction", "History", "Children's Books" |
+| **Syncs to** | Shopify (as Custom Collections) | Shopify and Squarespace (as tags/categories) |
+
+**Use collections** when you want to hand-pick specific books.
+**Use categories** when you want to organize books by genre or type.

--- a/docs/ftp-integration.md
+++ b/docs/ftp-integration.md
@@ -4,14 +4,14 @@ Bookhead accepts inventory files via secure FTP upload. Upload your CSV file, an
 
 ## Two ways to upload
 
-1. **Automated uploads**: Your POS system uploads files automatically
+1. **Automated uploads**: Your point-of-sale system uploads files automatically
 2. **Manual uploads**: You upload files yourself using an FTP client
 
 Both methods use the same secure server and file processing.
 
 ---
 
-## For POS Vendors
+## For point-of-sale Vendors
 
 ### Connection details
 - **Host**: files.bookhead.net
@@ -50,15 +50,15 @@ inventory.csv
 
 ## For Bookstores
 
-### Getting gtarted
+### Getting started
 1. **Contact us** at support@bookhead.net to get your FTP credentials
 2. **Prepare your inventory** as a CSV file (see format below)
-3. **Upload your file** using an FTP client or ask your POS provider to set up automatic uploads
+3. **Upload your file** using an FTP client or ask your point-of-sale provider to set up automatic uploads
 
-### POS integration status
-Bookhead works with any POS system that can export inventory via FTP. We can typically add support for a new POS provider within a few days of receiving sample data.
+### point-of-sale integration status
+Bookhead works with any point-of-sale system that can export inventory via FTP. We can typically add support for a new point-of-sale provider within a few days of receiving sample data.
 
-**Want to be an early adopter?** We're looking for bookstores to pilot integrations with their POS systems. [Email support@bookhead.net](mailto:support@bookhead.net) to discuss your POS setup.
+**Want to be an early adopter?** We're looking for bookstores to pilot integrations with their point-of-sale systems. [Email support@bookhead.net](mailto:support@bookhead.net) to discuss your point-of-sale setup.
 
 ### Manual upload with FTP clients
 
@@ -146,7 +146,7 @@ isbn,quantity,price,notes
 
 Email support@bookhead.net for:
 - FTP credentials setup
-- POS integration questions
+- point-of-sale integration questions
 - File format assistance
 - Technical troubleshooting
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 5
+---
+
+# Integrations
+
+Bookhead connects your point-of-sale system to multiple sales channels. Here's what we integrate with and how each one works.
+
+## Point-of-sale systems
+
+### Booklog
+
+Booklog is a point-of-sale system designed specifically for independent bookstores.
+
+| | |
+|--|--|
+| **Sync method** | Automatic FTP |
+| **Frequency** | Every 30 minutes |
+| **Setup** | Contact support@bookhead.net |
+
+Booklog automatically exports your full inventory to Bookhead's FTP server. When books are added, sold, or updated in Booklog, the changes sync to Bookhead and then to your sales channels.
+
+### IBID
+
+IBID is a point-of-sale system for independent bookstores.
+
+| | |
+|--|--|
+| **Sync method** | Automatic FTP |
+| **Frequency** | Every hour |
+| **Setup** | Contact support@bookhead.net |
+
+IBID automatically exports your inventory to Bookhead's FTP server on an hourly schedule.
+
+### Basil
+
+Basil is an inventory management system for bookstores.
+
+| | |
+|--|--|
+| **Sync method** | Manual file upload |
+| **Frequency** | On demand |
+| **Setup** | Self-service via admin |
+
+Basil doesn't support automatic exports, so you'll need to:
+1. Export your inventory from Basil as a CSV file
+2. Upload it to Bookhead via the [admin interface](/docs/inventory#2-upload-a-file-via-the-admin)
+
+We recommend uploading at least once a week, or whenever you have significant inventory changes.
+
+### Other point-of-sale systems
+
+Don't see your point-of-sale listed? Email support@bookhead.net. We can often add support for new systems within a few days of receiving sample data.
+
+---
+
+## Sales channels
+
+### Squarespace
+
+Squarespace is a website builder with e-commerce features.
+
+| | |
+|--|--|
+| **Sync method** | API |
+| **What syncs** | Products, inventory, prices, tags |
+| **Limitations** | Categories must be set via CSV import (API doesn't support categories) |
+
+**How it works:** Bookhead creates and updates products on your Squarespace store automatically. When inventory changes in your point-of-sale, Bookhead updates the Squarespace listing within 30 minutes.
+
+**Good to know:**
+- Product categories can't be set via API - you'll need to [import them via CSV](/docs/channels#importing-categories-to-squarespace)
+- Tags sync automatically and can be used for filtering
+- Inventory updates are near real-time
+
+**Setup:** [See Squarespace setup guide →](/docs/channels#squarespace)
+
+### Shopify
+
+Shopify is an e-commerce platform for online stores.
+
+| | |
+|--|--|
+| **Sync method** | API |
+| **What syncs** | Products, inventory, prices, collections, tags |
+| **Limitations** | None - full API support |
+
+**How it works:** Bookhead creates products, manages inventory, and syncs collections to your Shopify store. This is our most full-featured integration.
+
+**Good to know:**
+- Collections sync automatically from Bookhead
+- Full metafield support for rich product data
+- Inventory locations supported
+
+**Setup:** [See Shopify setup guide →](/docs/channels#shopify)
+
+### eBay
+
+eBay is an online marketplace.
+
+| | |
+|--|--|
+| **Sync method** | API |
+| **What syncs** | Listings, inventory |
+| **Best for** | Used and rare books |
+
+**How it works:** Bookhead creates listings on eBay for your inventory. Great for reaching buyers searching for specific titles.
+
+**Good to know:**
+- Listings are created in your eBay seller account
+- Inventory syncs when books sell or quantities change
+- Good for books that might not sell locally
+
+### Biblio
+
+Biblio is a marketplace specifically for used, rare, and out-of-print books.
+
+| | |
+|--|--|
+| **Sync method** | FTP/CSV |
+| **What syncs** | Listings, inventory |
+| **Best for** | Used and rare books |
+
+**How it works:** Bookhead exports your inventory to Biblio's format, making your books discoverable to collectors and book lovers.
+
+**Good to know:**
+- Biblio specializes in used and rare books
+- Great for reaching collectors
+- Syncs via scheduled file exports
+
+### Other channels
+
+We're always adding new integrations. If there's a platform you'd like to sell on, email support@bookhead.net to let us know.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,20 +3,40 @@ sidebar_position: 1
 ---
 
 # Overview
-Bookhead helps your independent bookstore sell books online. We do that with two products: Bookhead Connect and Bookhead Complete.
 
-## Bookhead Connect
+Bookhead helps your independent bookstore sell books online. We automatically sync your inventory to multiple sales channels - your point-of-sale system stays the source of truth, and Bookhead keeps everything else in sync.
 
-Bookhead Connect automatically syncs your bookstore inventory to multiple sales channels. We currently support listing your products on Squarespace, Biblio, and eBay. We can sync the local store inventory from your point of sales provider if they support inventory syncing with third parties. Currently we're able to sync with Basil and plan to integrate with other point of sales as we onboard more customers.
+## What we integrate with
 
-If you are interested in using Bookhead but we don't yet support your point of sales, please email sam@bookhead.net and we can work together with your point of sales provider to integrate automatic syncing.
+**Point-of-sale systems** (inventory source):
+- Booklog - automatic sync every 30 minutes
+- IBID - automatic sync every hour
+- Basil - manual file upload
+
+**Sales channels** (where you sell):
+- Squarespace - full product sync with inventory updates
+- Shopify - full product sync with collections support
+- eBay - marketplace listings
+- Biblio - used book marketplace
+
+[See all integrations →](./integrations.md)
+
+## How it works
+
+1. **Your point-of-sale syncs to Bookhead** - automatically via FTP or manual file upload
+2. **Bookhead enriches your data** with cover images, descriptions, and bibliographic metadata
+3. **Products sync to your channels** automatically - Squarespace, Shopify, eBay, Biblio
+4. **When books sell**, your point-of-sale updates, and Bookhead syncs the change everywhere
+
+You manage your inventory in your point-of-sale. Bookhead handles everything else.
+
+## Features
 
 ### [Managing your inventory](./inventory.md)
-Automatically sync the inventory from your point of sales provider to Bookhead. Includes an interface for importing, creating, and updating products.
+Automatically sync inventory from your point-of-sale provider. Includes an interface for importing, creating, and updating products manually when needed.
 
 ### [Selling on channels](./channels.md)
-List your inventory on multiple sales channels. It keeps the inventory up to date based on your store's local inventory.
+List your inventory on multiple sales channels. Keeps inventory up to date based on your store's local inventory.
 
-## Bookhead Complete
-
-Bookhead Complete includes a custom e-commerce storefront in addition to all of the inventory syncing and other features of Bookhead Connect. You can sell your products on an e-commerce website which includes content management controls like blogging and book lists.
+### [Collections and staff picks](./collections.md)
+Create curated book lists to feature on your website - staff recommendations, seasonal themes, and more.

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -14,44 +14,115 @@ Bookhead can create a book product enriched by an automatic bibliographic creati
 
 You can create books three different ways:
 
-### 1. Automatically via FTP
-We have an FTP server that can accept files automatically from your point of sales provider. Contact support@bookhead.net to set this up, because it requires coordination with your point of sales provider.
+### 1. Automatically via FTP (recommended)
 
-Each data source has a slightly different way of doing things, like with different column names or capitalization schemes, and Bookhead can work with a variety formats. Our system is designed so it's easy for us to add a new customer or point of sales.
+We have an FTP server that can accept files automatically from your point-of-sale provider. This is the recommended approach for keeping your inventory in sync. Contact support@bookhead.net to set this up, because it requires coordination with your point-of-sale provider.
+
+#### Supported point-of-sale systems
+
+We currently support automatic syncing with:
+
+| Point-of-sale | Sync Method | Frequency |
+|---------------|-------------|-----------|
+| **Booklog** | Automatic FTP | Every 30 minutes |
+| **IBID** | Automatic FTP | Every hour |
+| **Basil** | Manual file upload | On demand |
+
+**Note:** Basil doesn't support automatic exports, so you'll need to export your inventory from Basil and upload it to Bookhead manually. See [Upload a file via the admin](#2-upload-a-file-via-the-admin) below.
+
+Each data source has a slightly different way of doing things, like with different column names or capitalization schemes, and Bookhead can work with a variety of formats. Our system is designed so it's easy for us to add a new customer or point-of-sale.
+
+#### How the sync works
+
+1. **Your point-of-sale exports inventory** - Your point-of-sale system automatically sends an inventory file to our FTP server
+2. **Bookhead processes the file** - We parse the file and update our database with any changes (new books, price updates, quantity changes, deleted items)
+3. **Changes sync to channels** - Inventory changes are pushed to your connected sales channels (Squarespace, Shopify, etc.)
+
+**What gets synced:**
+- New books added to your inventory
+- Price changes
+- Quantity changes (including when items sell)
+- Books removed from inventory
+
+**Don't see your point-of-sale listed?** Email support@bookhead.net. We can often add support for new systems quickly.
 
 For detailed setup instructions, see our [FTP Integration Guide](ftp-integration.md).
 
 
 ### 2. Upload a file via the admin
-Visit `https://<store>.bookhead.net/staff/books/import/` to upload a file.
 
-The file must be a CSV file type, and the file is required to have these column names:
-- `isbn`
-- `quantity`
-- `price`
+If you can't use automatic FTP syncing, you can manually upload inventory files through the admin interface.
 
-We can accept these additional, optional fields:
-- `sku`
-- `ean`
-- `cost`
-- `first_edition`
-    - can be `True` or `False`. Defaults to `False`
-- `signed`
-    - can be `True` or `False`. Defaults to `False`
-- `advanced_reader_copy`
-    - can be `True` or `False`. Defaults to `False`
-- `notes`
-    - text field about the copy's condition or anything notable
-- `book_condition`
-    - choices:  `as-new`, `fine`, `very-good`, `good`, `fair`, `poor`
-- `jacket_condition`
-    - choices:  `as-new`, `fine`, `very-good`, `good`, `fair`, `poor`
+**To upload an inventory file:**
+
+1. Go to `https://<store>.bookhead.net/staff/books/import/`
+2. Click **Choose file** and select your CSV file
+3. Click **Upload**
+4. Bookhead will process your file and show you the results
+
+**What happens during import:**
+
+- **New ISBNs** are looked up and created with bibliographic data (cover, description, etc.)
+- **Existing ISBNs** are updated with the new price/quantity
+- **Invalid ISBNs** are flagged so you can fix them
+- You'll see a summary of what was created, updated, and any errors
+
+#### Required fields
+
+Your CSV file must have these columns:
+
+| Column | Description |
+|--------|-------------|
+| `isbn` | The book's ISBN (10 or 13 digit) |
+| `quantity` | How many copies you have |
+| `price` | Your selling price |
+
+#### Optional fields
+
+You can also include these columns:
+
+| Column | Description | Values |
+|--------|-------------|--------|
+| `sku` | Your internal product ID | Any text |
+| `ean` | EAN barcode | Number |
+| `cost` | Your cost for the item | Number |
+| `book_condition` | Condition of the book | `as-new`, `fine`, `very-good`, `good`, `fair`, `poor` |
+| `jacket_condition` | Condition of dust jacket | `as-new`, `fine`, `very-good`, `good`, `fair`, `poor` |
+| `first_edition` | Is it a first edition? | `True` or `False` |
+| `signed` | Is it signed? | `True` or `False` |
+| `advanced_reader_copy` | Is it an ARC? | `True` or `False` |
+| `notes` | Notes about this copy | Any text |
 
 
 ### 3. Manually in the admin
-Visit `https://<store>.bookhead.net/staff/books/new/` and you can use the form to create a new book. 
 
-You can search bibliographic data by ISBN or title. The ISBN search has better bibliographic data. The title search uses data from Open Library, which can be handy when your edition predates ISBNs (also, this search doesn't always return complete data, but it can still be helpful for filling out some basics of your title).
+Sometimes you need to add a book that isn't in your point-of-sale yet, or create a listing for a special item. You can do this directly in Bookhead.
+
+**To create a new book:**
+
+1. Go to your staff dashboard: `https://<store>.bookhead.net/staff/`
+2. Click **New book** (or go directly to `/staff/books/new/`)
+3. Search for the book by **ISBN** (recommended) or **title**
+4. Select the correct edition from the search results
+5. Fill in the copy details:
+   - **Price**: Your selling price
+   - **Quantity**: How many you have
+   - **Condition**: Book and jacket condition
+   - **Notes**: Any special details (signed, first edition, etc.)
+6. Click **Save**
+
+**Search tips:**
+
+- **ISBN search** gives the best results - we pull detailed bibliographic data including cover images
+- **Title search** uses Open Library data, which is helpful for older books that predate ISBNs
+- If a book isn't found, you can create it manually by entering the bibliographic details yourself
+
+**When to use manual creation:**
+
+- Adding a rare or unique item not in your point-of-sale
+- Creating listings for items your point-of-sale doesn't track (signed editions, ARCs)
+- Testing a new listing before adding it to your point-of-sale
+- Adding books while your point-of-sale sync is being set up
 
 ## About Bookhead's data model
 Our bibliographic data model drives everything about Bookhead. Within the context of storing bibliographic metadata about your inventory in a database, a *book* doesn't exactly describe the object you're trying to sell. Instead, a "work" can have multiple "editions", and each edition can have unique "copies" with altering attributes. Solving this bibliographic data problem has a long history in library science, so we created a bibliographic data model inspired by [the Open Library's database design](https://openlibrary.org/dev/docs/api/books) and [Functional Requirements for Bibliographic Records](https://en.wikipedia.org/wiki/Functional_Requirements_for_Bibliographic_Records). We applied our own take that is simple for the needs of online book retail. This is still a work in progress as we continually encounter new sources of bibliographic data and prioritize missing parts (for example, we currently don't support BISAC codes because it's not been a priority, but it would be easy to add once a new data source or customer requires this). We've found this data model has been reliable and flexible to change as this application has evolved over time.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Bookhead Documentation',
-  tagline: 'Software for independent bookstores',
+  tagline: 'Sync your bookstore inventory to Squarespace, Shopify, eBay, and more',
   favicon: 'img/bookhead-single.png',
 
   // Set the production url of your site here
@@ -75,11 +75,36 @@ const config = {
         style: 'dark',
         links: [
           {
-            title: 'Docs',
+            title: 'Documentation',
             items: [
               {
-                label: 'Documentation',
+                label: 'Overview',
                 to: '/docs/intro',
+              },
+              {
+                label: 'Integrations',
+                to: '/docs/integrations',
+              },
+              {
+                label: 'Managing inventory',
+                to: '/docs/inventory',
+              },
+              {
+                label: 'Selling on channels',
+                to: '/docs/channels',
+              },
+            ],
+          },
+          {
+            title: 'Features',
+            items: [
+              {
+                label: 'Collections & staff picks',
+                to: '/docs/collections',
+              },
+              {
+                label: 'FTP integration',
+                to: '/docs/ftp-integration',
               },
             ],
           },
@@ -97,7 +122,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} Bookhead. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Bookhead.`,
       },
       // prism: {
       //   theme: lightCodeTheme,

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -4,29 +4,29 @@ import styles from './styles.module.css';
 
 const FeatureList = [
   {
-    title: 'Inventory sync',
+    title: 'Point-of-sale integrations',
     Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
     description: (
       <>
-        Bookhead automatically syncs your inventory to your e-commerce store behind the scenes while you focus on selling books.
+        Connect your point-of-sale system (Booklog, IBID, Basil) and let Bookhead automatically sync your inventory.
       </>
     ),
   },
   {
-    title: 'Choose your own platform',
+    title: 'Sell on multiple channels',
     Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
     description: (
       <>
-        Bookhead allows you to use the software you want.
+        List your books on Squarespace, Shopify, eBay, and Biblio. Inventory stays in sync across all platforms.
       </>
     ),
   },
   {
-    title: 'Support',
+    title: 'Rich book data',
     Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
     description: (
       <>
-        Reach out to <a href="mailto:support@bookhead.net"><strong>support@bookhead.net</strong></a> for help.
+        Bookhead enriches your listings with cover images, descriptions, and bibliographic metadata automatically.
       </>
     ),
   },


### PR DESCRIPTION
## Summary
- Add integrations page with details for each point-of-sale and channel
- Add collections and staff picks documentation  
- Expand inventory management docs (sync details, manual creation)
- Add categories documentation to channels page
- Update homepage tagline and features
- Update footer with all doc links
- Fix terminology and sync frequencies
- Remove Bookhead Connect/Complete distinction

## Pages added/updated
- `docs/integrations.md` (new)
- `docs/collections.md` (new)
- `docs/intro.md`
- `docs/inventory.md`
- `docs/channels.md`
- `docs/ftp-integration.md`
- `docusaurus.config.js`
- `src/components/HomepageFeatures/index.js`